### PR TITLE
Change Password Bug Fix

### DIFF
--- a/SRC/website/backend/controllers/userController.js
+++ b/SRC/website/backend/controllers/userController.js
@@ -311,6 +311,23 @@ const passwordReset = async (req, res) => {
 		return next(error);
 	}
 
+	// Check if email exists in our database
+	let emailExists;
+	try {
+		emailExists = await User.findOne({email});
+	} catch (err) {
+		const error = new HttpError("Signing up failed, please try again");
+		return next(error);
+	}
+	if (emailExists) {
+		// we are good
+	} else {
+		return res.json({
+			emailExists: false,
+			message: "Email is not registered with us, please check your email"
+		});
+	}
+
 	// Check if token exists
 	let tokenExists;
 	try {

--- a/SRC/website/frontend/public/style.css
+++ b/SRC/website/frontend/public/style.css
@@ -314,6 +314,13 @@ p.success-text {
     text-align: left;
 	margin-top: 6px;
 }
+p.failure-text {
+	font-size: 14px;
+	color: #ac4b49;
+    font-weight: 500;
+	text-align: left;
+	margin-top: 6px;
+}
 p.forgot_password {
 	font-size: 13px;
 	margin-top: 14px;
@@ -871,6 +878,9 @@ li.user:hover ul {
 	box-shadow: 0 7px 16px 0 rgba(50, 50, 50, 0.2);
 	-moz-box-shadow: 0 7px 16px 0 rgba(50, 50, 50, 0.2);
 	-webkit-box-shadow: 0 7px 16px rgba(50, 50, 50, 0.2);
+}
+.login-form button[type=submit]:disabled {
+	opacity: 0.6;
 }
 .error_text {
 	font-size: 12px;

--- a/SRC/website/frontend/src/components/ChangePassword.js
+++ b/SRC/website/frontend/src/components/ChangePassword.js
@@ -13,7 +13,7 @@ const ChangePassword = () => {
     // Get the email and token param from the URL.
     const useQuery = () => {
         const { search } = useLocation();
-        return React.useMemo(() => new URLSearchParams(search), [search]);
+        return useMemo(() => new URLSearchParams(search), [search]);
     };
     let query = useQuery();
 
@@ -23,7 +23,7 @@ const ChangePassword = () => {
             // check if token is valid otherwise redirect to home page
 			axios.get(`/api/check_token?email=${query.get("email")}&token=${query.get("token")}`)
 				.then(resp => {
-					console.log("resp", resp);
+					// console.log("resp", resp);
 					if (resp.data.token_exists == false) {
 						// redirect to home page if token does not exist
 						return history.push('/');
@@ -35,7 +35,7 @@ const ChangePassword = () => {
         }
     }, []);
     
-
+	const [passwordMismatch, setPasswordMismatch] = useState(false);
 	const [password, setPassword] = useState('');
 	const [passwordError, setPasswordError] = useState('');
     const [confirmPassword, setConfirmPassword] = useState('');
@@ -44,10 +44,12 @@ const ChangePassword = () => {
 	const passwordHandler = (event) => {
 		setPassword(event.target.value.trim());
         setPasswordError('');
+		setPasswordMismatch(false);
 	}
     const confirmPasswordHandler = (event) => {
 		setConfirmPassword(event.target.value.trim());
         setConfirmPasswordError('');
+		setPasswordMismatch(false);
 	}
 
 	// Scroll to top of page
@@ -74,7 +76,9 @@ const ChangePassword = () => {
 			return false;
 		}
         if (password !== confirmPassword) {
-            return dispatch(receiveFailureMessage({failure: "Password and confirm password do not match"}));
+			setPasswordMismatch(true);
+            dispatch(receiveFailureMessage({failure: "Password and confirm password do not match"}));
+			return false;
         }
 		return true;
 	}
@@ -91,7 +95,7 @@ const ChangePassword = () => {
 			};
 			axios.put('/api/change_password', data)
 				.then(resp => {
-					console.log('resp', resp);
+					// console.log('resp', resp);
 					if (resp.data.success) {
 						dispatch(receiveSuccessMessage({success: "Password changed successfully"}));
 						return history.push('/login');
@@ -111,6 +115,12 @@ const ChangePassword = () => {
 			<div className="gray-bg">
 				<div className="container login-form p-60">
 					<div className="p-lr">
+						{passwordMismatch &&
+							<div className="card">
+								<p><strong>Failure</strong></p>
+								<p className="failure-text">Password and confirm password do not match</p>
+							</div>
+						}
 						<div className="card">
 							<div className="title">Change Password</div>
 							<form>

--- a/SRC/website/frontend/src/components/PasswordReset.js
+++ b/SRC/website/frontend/src/components/PasswordReset.js
@@ -8,9 +8,14 @@ const PasswordReset = () => {
 	const [emailError, setEmailError] = useState('');
 	const [passwordReqSent, setPasswordReqSent] = useState(false);
 	const [passwordReqAlreadySent, setPasswordReqAlreadySent] = useState(false);
+	const [emailDoesNotExist, setEmailDoesNotExist] = useState(false);
+	const [disableContinue, setDisableContinue] = useState(true);
+
+	
 
 	const emailHandler = (event) => {
 		setEmail(event.target.value.toLowerCase().trim());
+		setDisableContinue(false);
         setEmailError('');
 	};
 
@@ -43,13 +48,22 @@ const PasswordReset = () => {
 			};
 			axios.post('/api/password_reset', body)
 				.then(resp => {
-					console.log("resp", resp);
+					setDisableContinue(true);
+					// console.log("resp", resp);
+					if (resp.data.emailExists === false) {
+						setPasswordReqSent(false);
+						setPasswordReqAlreadySent(false);
+						return setEmailDoesNotExist(true);
+					}
 					if (resp.data.token === "exists") {
 						setPasswordReqSent(false);
+						setEmailDoesNotExist(false);
 						return setPasswordReqAlreadySent(true);
 					}
 					if (resp.data.type === "success") {
-						setPasswordReqSent(true);
+						setEmailDoesNotExist(false);
+						setPasswordReqAlreadySent(false);
+						return setPasswordReqSent(true);
 					}
 				});
 		}
@@ -78,6 +92,12 @@ const PasswordReset = () => {
 								<p className="success-text">Please check your email, we have already sent you instructions to reset your password</p>
 							</div>
 						}
+						{emailDoesNotExist &&
+							<div className="card">
+								<p><strong>Failure</strong></p>
+								<p className="failure-text">Please check your email, entered email does not exist in our records</p>
+							</div>
+						}
 						
 						<div className="card">
 							<div className="title">Password Reset</div>
@@ -93,7 +113,7 @@ const PasswordReset = () => {
 								/>
 								{emailError !== "" && <p className="error_text"><i>!</i> &nbsp;{emailError}</p>}
 
-								<button type="submit" onClick={handlePasswordReset}>Continue</button>
+								<button type="submit" onClick={handlePasswordReset} disabled={disableContinue}>Continue</button>
 							
 							</form>
 						</div>


### PR DESCRIPTION
There was a bug in frontend validation, when user enters password and confirm password both inputs should be same only then allow API call. Previously there was validation but still API was getting called.
Wrote conditions to handle various other errors such as:

- when token already generated
- when email is not registered with us
- when password and confirm password do not match